### PR TITLE
fix(workflows): quote $RUNNER_TEMP to prevent shell globbing

### DIFF
--- a/.github/workflows/publish-npm.generated.yml
+++ b/.github/workflows/publish-npm.generated.yml
@@ -25,11 +25,11 @@ jobs:
         uses: actions/checkout@v5
       - name: Install mise
         uses: jdx/mise-action@v3
-      - run: mkdir -p $RUNNER_TEMP/out
+      - run: "mkdir -p \"$RUNNER_TEMP/out\""
       - name: Publish package
         env: 
           NPM_CONFIG_PROVENANCE: "true"
-        run: mise run clone-to-npm --publish --ci -d $RUNNER_TEMP/out --skip-publish
+        run: "mise run clone-to-npm --publish --ci -d \"$RUNNER_TEMP/out\" --skip-publish"
       - run: pwd && ls -la
         working-directory: /home/runner/work/_temp/out/npm
       - uses: actions/setup-node@v4

--- a/.github/workflows/publish-npm.main.ts
+++ b/.github/workflows/publish-npm.main.ts
@@ -33,13 +33,13 @@ echo "version=\${VERSION}" >> "$GITHUB_OUTPUT"`,
           run: `echo "Hello world! Publishing version \${{ steps.version.outputs.version }}"`,
         },
         ...checkoutAndInstallMise(),
-        { run: `mkdir -p $RUNNER_TEMP/out` },
+        { run: `mkdir -p "$RUNNER_TEMP/out"` },
         {
           name: "Publish package",
           env: {
             NPM_CONFIG_PROVENANCE: "true",
           },
-          run: `mise run clone-to-npm --publish --ci -d $RUNNER_TEMP/out --skip-publish`,
+          run: `mise run clone-to-npm --publish --ci -d "$RUNNER_TEMP/out" --skip-publish`,
         },
         {
           run: "pwd && ls -la",


### PR DESCRIPTION
- Fix SC2086 shellcheck warnings in publish-npm workflow
- Quote $RUNNER_TEMP/out in mkdir and mise run commands
- Regenerate publish-npm.generated.yml

Fixes actionlint violations.