### PR TITLE
Format git config multiline

### DIFF
--- a/.github/workflows/gha-ts.main.ts
+++ b/.github/workflows/gha-ts.main.ts
@@ -125,29 +125,29 @@ const wf = workflow({
         },
         {
           name: "Verify if TS workflows are converted",
-          run: `CHANGED="$(git --no-pager diff --name-only)";
-            if [ -n "$CHANGED" ]; then
-              echo "::error title=TS workflows are not up to date::Run 'mise run workflows:build' locally, commit, and push.";
-              echo "::group::Changed files";
-              echo "$CHANGED";
-              echo "::endgroup::";
-              while IFS= read -r file; do
-                [ -z "$file" ] && continue;
-                echo "::notice file=$file,line=1,title=Changed file::Update generated YAML for this file";
-              done <<< "$CHANGED";
-              {
-                echo "### TS workflows are not up to date";
-                echo;
-                echo "Run: mise run workflows:build";
-                echo;
-                echo "Then commit the updated files and push.";
-                echo;
-                echo "Changed files:";
-                echo;
-                echo "$CHANGED" | awk '{print "- " $0}';
-              } >> "$GITHUB_STEP_SUMMARY";
-              exit 1;
-            fi`,
+          run: `CHANGED="$(git --no-pager diff --name-only)"
+if [ -n "$CHANGED" ]; then
+  echo "::error title=TS workflows are not up to date::Run 'mise run workflows:build' locally, commit, and push."
+  echo "::group::Changed files"
+  echo "$CHANGED"
+  echo "::endgroup::"
+  while IFS= read -r file; do
+    [ -z "$file" ] && continue
+    echo "::notice file=$file,line=1,title=Changed file::Update generated YAML for this file"
+  done <<< "$CHANGED"
+  {
+    echo "### TS workflows are not up to date"
+    echo
+    echo "Run: mise run workflows:build"
+    echo
+    echo "Then commit the updated files and push."
+    echo
+    echo "Changed files:"
+    echo
+    echo "$CHANGED" | awk '{print "- " $0}'
+  } >> "$GITHUB_STEP_SUMMARY"
+  exit 1
+fi`,
         },
       ],
     },

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -21,6 +21,63 @@ export class Serializer {
     private options?: RenderOptions,
   ) {}
 
+  // Sentinel used to mark strings that should be rendered as YAML block scalars
+  // We encode the original value as base64 to avoid escaping issues during
+  // the YAML stringify phase, then replace the sentinel with a block literal
+  // in the final output while preserving indentation.
+  private static readonly BLOCK_SENTINEL = "__GHA_TS_BLOCK__";
+
+  private static toBase64(input: string): string {
+    // Node and Bun both provide Buffer
+    return Buffer.from(input, "utf8").toString("base64");
+  }
+
+  private static fromBase64(input: string): string {
+    return Buffer.from(input, "base64").toString("utf8");
+  }
+
+  // Walk an arbitrary object and, for any step `run` string that contains
+  // newlines, replace it with a sentinel-encoded string. This allows us to
+  // post-process the YAML and emit a block scalar (`|-") for readability.
+  private static markMultilineRunValues(value: unknown): unknown {
+    if (Array.isArray(value)) {
+      return value.map((v) => Serializer.markMultilineRunValues(v));
+    }
+    if (value && typeof value === "object") {
+      const out: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+        if (k === "run" && typeof v === "string" && v.includes("\n")) {
+          out[k] = `${Serializer.BLOCK_SENTINEL}:${Serializer.toBase64(v)}`;
+        } else {
+          out[k] = Serializer.markMultilineRunValues(v);
+        }
+      }
+      return out;
+    }
+    return value;
+  }
+
+  // Replace sentinel-marked `run` values that the YAML stringifier emitted as a
+  // normal quoted string with an actual YAML block scalar. The regex preserves
+  // original indentation and uses `|-` chomping to avoid adding a trailing
+  // newline.
+  private static replaceSentinelsWithBlockScalars(yamlText: string): string {
+    const pattern = new RegExp(
+      // capture indentation and quoted sentinel payload on a single line
+      String.raw`^([ \t]*)run:[ \t]*(["'])${Serializer.BLOCK_SENTINEL}:(.+?)\2[ \t]*$`,
+      "gm",
+    );
+    return yamlText.replace(pattern, (_m, indent: string, _q: string, b64: string) => {
+      const decoded = Serializer.fromBase64(b64);
+      const contentIndent = indent + "  ";
+      const lines = decoded.split("\n");
+      const block =
+        indent + "run: |-" + "\n" +
+        lines.map((ln) => contentIndent + ln).join("\n");
+      return block;
+    });
+  }
+
   public setOptions(options: RenderOptions): Serializer {
     this.options = { ...this.options, ...options };
     return this;
@@ -36,15 +93,19 @@ export class Serializer {
 
   public stringifyWorkflow(): string {
     const obj = toYamlReadyObject(this.workflow);
+    // Mark multiline `run` values before stringification so we can convert them
+    // into YAML block scalars afterwards in a renderer-agnostic way.
+    const objWithBlocks = Serializer.markMultilineRunValues(obj);
     if (this.options?.stringify) {
-      const yamlBody = this.options.stringify(obj, null, 2);
+      const yamlBodyRaw = this.options.stringify(objWithBlocks, null, 2);
+      const yamlBody = Serializer.replaceSentinelsWithBlockScalars(yamlBodyRaw);
       return (
         (this.options?.header ?? HEADER) +
         yamlBody +
         (yamlBody.endsWith("\n") ? "" : "\n")
       );
     }
-    return JSON.stringify(obj, null, 2);
+    return JSON.stringify(objWithBlocks, null, 2);
   }
 
   public writeWorkflow(filePath: string): void {


### PR DESCRIPTION
Render multiline `run` step commands as YAML block scalars to improve readability.

Bun's `Bun.YAML.stringify` does not automatically emit block scalars for multiline strings. To achieve the desired formatting, a post-processing step was introduced in `src/render/index.ts`. This involves marking multiline `run` values with a sentinel before stringification and then replacing these sentinels with properly indented YAML block scalars (`|-`) in the final output.

---
<a href="https://cursor.com/background-agent?bcId=bc-0b164104-cf37-4fdd-81da-451318e0031b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0b164104-cf37-4fdd-81da-451318e0031b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

