### PR TITLE
Rename last fetchDepth mentions in examples after #32

### DIFF
--- a/examples/hello-world-bun/.github/workflows/hello-world.main.ts
+++ b/examples/hello-world-bun/.github/workflows/hello-world.main.ts
@@ -14,7 +14,7 @@ const wf = workflow({
     exampleJob: {
       "runs-on": "ubuntu-latest",
       steps: [
-        checkout({ fetchDepth: 0 }),
+        checkout({ "fetch-depth": 0 }),
         { name: "Test", run: "echo 'Hello, world!'" },
       ],
     },

--- a/examples/hello-world-deno/.github/workflows/hello-world.main.ts
+++ b/examples/hello-world-deno/.github/workflows/hello-world.main.ts
@@ -14,7 +14,7 @@ const wf = workflow({
     exampleJob: {
       "runs-on": "ubuntu-latest",
       steps: [
-        checkout({ fetchDepth: 0 }),
+        checkout({ "fetch-depth": 0 }),
         { name: "Test", run: "echo 'Hello, world!'" },
       ],
     },

--- a/examples/hello-world-node/.github/workflows/hello-world.main.ts
+++ b/examples/hello-world-node/.github/workflows/hello-world.main.ts
@@ -14,7 +14,7 @@ export const wf = workflow({
     exampleJob: {
       "runs-on": "ubuntu-latest",
       steps: [
-        checkout({ fetchDepth: 0 }),
+        checkout({ "fetch-depth": 0 }),
         { name: "Test", run: "echo 'Hello, world!'" },
       ],
     },


### PR DESCRIPTION
Update `fetchDepth` to `"fetch-depth"` in example workflow files to align with a recent change.

---
<a href="https://cursor.com/background-agent?bcId=bc-83274e8e-7339-4a65-95f3-a32abd068245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-83274e8e-7339-4a65-95f3-a32abd068245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

