### PR TITLE
Make workflow and job functions generic

### DIFF
--- a/src/workflow-types.ts
+++ b/src/workflow-types.ts
@@ -272,10 +272,10 @@ export const permissionsAllRead: PermissionsAllValue = "read-all";
 export const permissionsAllWrite: PermissionsAllValue = "write-all";
 
 // Simple factories to aid composition
-export function workflow(def: Workflow): Workflow {
+export function workflow<W extends Workflow>(def: W): W {
   return def;
 }
-export function job(def: DefaultJob): DefaultJob {
+export function job<J extends DefaultJob>(def: J): J {
   return def;
 }
 export function uses(


### PR DESCRIPTION
Hi! Love this - have built crappy versions of this a couple of times, but I want this to be The One so might come here with the occasional suggestion/question.

First a small thing - I found myself using `{...} satisfies Workflow`  rather than the nicer-looking `workflow({ ... })` because it allowed me to import another workflow, and access it type-safely:

```ts
import otherWorkflow from './other-workflow.ts'
import { Workflow } from '@jlarky/gha-ts/workflow-types'

export default {
  on: {
    pull_request: {},
    on: otherWorkflow.on.workflow_dispatch,
  },
  jobs: {...}
} satisfies Workflow
```

(also, in case you're interested, here's a fairly hastily put together thing which auto-updates yaml in our iterate repo from typescript: https://github.com/iterate/iterate/pull/422 - suggestions on how else to do it welcome, some details of why i didn't use the built-in `generate*` functions in the PR description)