### PR TITLE
Allow 'inherit' option for secrets in ReusableJob

### DIFF
--- a/src/workflow-types.ts
+++ b/src/workflow-types.ts
@@ -62,7 +62,9 @@ export interface WorkflowCallTrigger {
       description?: string;
     }
   >;
-  secrets?: Record<string, { required?: boolean; description?: string }>;
+  secrets?:
+    | Record<string, { required?: boolean; description?: string }>
+    | "inherit";
   outputs?: Record<string, { description?: string; value: string }>;
 }
 


### PR DESCRIPTION
example usage (vscode github actions yaml extension autocompletes this/validates if you typo):

<img width="458" height="148" alt="image" src="https://github.com/user-attachments/assets/4fa9b12c-e543-4e04-8233-23572834e859" />
