### PR TITLE
Update lines helper: support substitutions, tabs, and fix trailing newline

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -87,21 +87,23 @@ export function lines(
     }
   }
 
+  let result: string;
   if (hasAnyIndentation && minIndent > 0 && minIndent !== Infinity) {
-    return (
-      linesArray
-        .map((line) => {
-          if (line && line.length >= minIndent) {
-            const leadingWhitespace = line.match(/^(\s+)/)?.[1];
-            if (leadingWhitespace && leadingWhitespace.length >= minIndent) {
-              return line.slice(minIndent);
-            }
+    result = linesArray
+      .map((line) => {
+        if (line && line.length >= minIndent) {
+          const leadingWhitespace = line.match(/^(\s+)/)?.[1];
+          if (leadingWhitespace && leadingWhitespace.length >= minIndent) {
+            return line.slice(minIndent);
           }
-          return line;
-        })
-        .join("\n") + "\n"
-    );
+        }
+        return line;
+      })
+      .join("\n");
   } else {
-    return linesArray.join("\n") + "\n";
+    result = linesArray.join("\n");
   }
+
+  // Only add trailing newline if result doesn't already end with one
+  return result.endsWith("\n") ? result : result + "\n";
 }

--- a/tests/lines-helper.test.ts
+++ b/tests/lines-helper.test.ts
@@ -185,4 +185,20 @@ echo World`);
     const result = lines`hello \${world}`;
     expect(result).toBe("hello ${world}\n");
   });
+
+  test("does not add double trailing newline when input already ends with one", () => {
+    // When input string already ends with newline, result should not have double newline
+    const input = "line1\nline2\n";
+    const result = lines(input);
+    expect(result).toBe("line1\nline2\n");
+    expect(result.endsWith("\n\n")).toBe(false);
+    expect(result.match(/\n\n$/)).toBeNull();
+  });
+
+  test("handles input that is just a newline", () => {
+    // Input that's just "\n" should return "\n" (not "\n\n")
+    const result = lines("\n");
+    expect(result).toBe("\n");
+    expect(result).not.toBe("\n\n");
+  });
 });


### PR DESCRIPTION
## Changes

- **Support template literal substitutions**: The `lines` function now properly handles template literal interpolations (e.g., `lines`hello ${world}``)
- **Support tabs in addition to spaces**: Updated indentation detection to handle both tabs and spaces for dedenting
- **Fix trailing newline regression**: Only adds trailing `\n` if the result doesn't already end with one, preventing double newlines
- **Improved whitespace handling**: Uses `\s+` instead of space-only regex for better whitespace detection

## Testing

- All existing tests updated and passing (20 tests)
- Added test for template literal substitutions
- Added test for trailing newline edge cases
- Test updated to reflect that tabs are now supported

## Breaking Changes

None - the changes are backward compatible. The function now has additional capabilities but maintains the same behavior for existing use cases.