### PR TITLE
Fix TypeScript deprecation and module resolution issues

### DIFF
--- a/.github/build.ts
+++ b/.github/build.ts
@@ -1,7 +1,7 @@
 import "./workflows/gha-ts.main";
 import "./workflows/example-bun.main";
 import "./workflows/example-node.main";
-import "./workflows/example-javascript.main";
+import "./workflows/example-javascript.main.mjs";
 import "./workflows/test.main";
 import "./workflows/publish.main";
 import "./workflows/publish-npm.main";

--- a/.github/workflows/example-javascript.generated.yml
+++ b/.github/workflows/example-javascript.generated.yml
@@ -23,7 +23,7 @@ jobs:
         run: git diff --exit-code .github/workflows/example-javascript.generated.yml
       - name: Type-Check
         run: tsc --noEmit --skipLibCheck --allowJs --module nodenext --moduleResolution
-          nodenext .github/workflows/example-javascript.main.mjs
+          nodenext .github/workflows/example-javascript.main.mjs --ignoreConfig
   exampleJob:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/example-javascript.main.mjs
+++ b/.github/workflows/example-javascript.main.mjs
@@ -35,7 +35,7 @@ const wf = workflow({
         },
         {
           name: "Type-Check",
-          run: "tsc --noEmit --skipLibCheck --allowJs --module nodenext --moduleResolution nodenext .github/workflows/example-javascript.main.mjs",
+          run: "tsc --noEmit --skipLibCheck --allowJs --module nodenext --moduleResolution nodenext .github/workflows/example-javascript.main.mjs --ignoreConfig",
         },
       ],
     },

--- a/examples/hello-world-node-20/.github/workflows/hello-world.main.mjs
+++ b/examples/hello-world-node-20/.github/workflows/hello-world.main.mjs
@@ -35,7 +35,7 @@ const wf = workflow({
         },
         {
           name: "Type-Check",
-          run: "tsc --noEmit --skipLibCheck --allowJs --module nodenext --moduleResolution nodenext .github/workflows/example-javascript.main.mjs",
+          run: "tsc --noEmit --skipLibCheck --allowJs --module nodenext --moduleResolution nodenext .github/workflows/example-javascript.main.mjs --ignoreConfig",
         },
       ],
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,6 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "types": ["bun-types", "node"],
-    "baseUrl": ".",
     "allowJs": true,
     "checkJs": true,
     "paths": {


### PR DESCRIPTION
This PR addresses the deprecation of `baseUrl` in TypeScript 6.0+ when using `moduleResolution: "Bundler"`. It also fixes a module resolution error in `.github/build.ts` where an ESM import was missing the required file extension.

Changes:
- Removed `"baseUrl": "."` from `tsconfig.json`.
- Updated `import "./workflows/example-javascript.main"` to `import "./workflows/example-javascript.main.mjs"` in `.github/build.ts`.
- Verified changes with `tsc --noEmit` and `bun test`.

---
*PR created automatically by Jules for task [9038164864356176280](https://jules.google.com/task/9038164864356176280) started by @JLarky*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove deprecated `baseUrl` in TypeScript 6 with `moduleResolution: "Bundler"` (TS5101) and fix ESM resolution by using `.mjs` in `.github/build.ts`. Add `--ignoreConfig` to targeted `tsc` runs in workflows to avoid TS5112.

<sup>Written for commit 1219d04284d1cdcfb9e922772b1dd0d08b09054c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

