### PR TITLE
Trigger Publish workflow on release published, not push to main

### DIFF
--- a/.github/workflows/publish.generated.yml
+++ b/.github/workflows/publish.generated.yml
@@ -3,9 +3,11 @@
 
 name: Publish
 "on": 
-  push: 
-    branches: 
-      - main
+  release: 
+    types: 
+      - published
+  workflow_dispatch: 
+    {}
 permissions: 
   contents: read
   id-token: write

--- a/.github/workflows/publish.main.ts
+++ b/.github/workflows/publish.main.ts
@@ -7,9 +7,8 @@ import { generateWorkflow } from "@jlarky/gha-ts/cli";
 const wf = workflow({
   name: "Publish",
   on: {
-    push: {
-      branches: ["main"],
-    },
+    release: { types: ["published"] },
+    workflow_dispatch: {},
   },
   permissions: {
     contents: "read",


### PR DESCRIPTION
## Summary
Align the JSR Publish trigger with the pattern used in [JLarky/lima-escape](https://github.com/JLarky/lima-escape/blob/main/.github/workflows/publish.main.ts) and [JLarky/lima-code](https://github.com/JLarky/lima-code/blob/main/.github/workflows/publish.main.ts): real publishes only happen when a GitHub release is actually published.

```diff
   on: {
-    push: {
-      branches: ["main"],
-    },
+    release: { types: ["published"] },
+    workflow_dispatch: {},
   },
```

## Why this isn't a correctness fix
\`bunx jsr publish\` already no-ops on already-published versions (\`Warning: Skipping, already published @jlarky/gha-ts@0.2.1\`, exit 0), so the previous trigger wasn't producing red CI. This is purely a clarity change — the workflow's trigger now matches the event that actually causes a publish, and matches the convention used across the other @jlarky Deno packages.

## Release flow (already in place)
1. Bump \`version\` in \`jsr.json\` → push to \`main\`.
2. \`create-release\` drafts a \`v<version>\` GitHub release (existing behavior).
3. Review the draft → click **Publish release**.
4. \`publish\` fires → \`bunx jsr publish\` via OIDC.

\`workflow_dispatch\` is kept so the workflow can still be triggered manually if needed.

## Test plan
- [x] \`mise run workflows:build\` regenerates \`publish.generated.yml\` cleanly
- [ ] After merge, confirm a no-op push to \`main\` no longer triggers the Publish workflow
- [ ] On the next \`jsr.json\` bump, confirm \`create-release\` drafts a release and publishing it fires the Publish workflow successfully via OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the Publish workflow to run on GitHub release publish instead of pushes to `main`, keeping manual runs via `workflow_dispatch`. This matches other `@jlarky` packages and avoids unnecessary runs.

- **Refactors**
  - Change trigger to `release: ["published"]`; remove `push: branches: ["main"]`.
  - Keep `workflow_dispatch` for manual triggers.
  - No behavior change; `bunx jsr publish` already no-ops on published versions.

<sup>Written for commit 891c979278de169b74b3cc7de2a5f8ecc81ce6ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

