### PR TITLE
Bump actions/checkout helper from v4 to v5

### DIFF
--- a/.github/workflows/example-bun.generated.yml
+++ b/.github/workflows/example-bun.generated.yml
@@ -12,7 +12,7 @@ jobs:
   exampleJob: 
     runs-on: ubuntu-latest
     steps: 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with: 
           fetch-depth: 0
       - name: Test

--- a/.github/workflows/example-bun.generated.yml
+++ b/.github/workflows/example-bun.generated.yml
@@ -12,7 +12,7 @@ jobs:
   exampleJob: 
     runs-on: ubuntu-latest
     steps: 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with: 
           fetch-depth: 0
       - name: Test

--- a/.github/workflows/example-javascript.generated.yml
+++ b/.github/workflows/example-javascript.generated.yml
@@ -11,7 +11,7 @@ jobs:
   selfCheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install dependencies
         working-directory: .github/workflows
         run: npm install @jlarky/gha-ts typescript yaml
@@ -27,7 +27,7 @@ jobs:
   exampleJob:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Test

--- a/.github/workflows/example-javascript.generated.yml
+++ b/.github/workflows/example-javascript.generated.yml
@@ -11,7 +11,7 @@ jobs:
   selfCheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
       - name: Install dependencies
         working-directory: .github/workflows
         run: npm install @jlarky/gha-ts typescript yaml
@@ -27,7 +27,7 @@ jobs:
   exampleJob:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Test

--- a/.github/workflows/example-node.generated.yml
+++ b/.github/workflows/example-node.generated.yml
@@ -11,7 +11,7 @@ jobs:
   exampleJob:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Test

--- a/.github/workflows/example-node.generated.yml
+++ b/.github/workflows/example-node.generated.yml
@@ -11,7 +11,7 @@ jobs:
   exampleJob:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Test

--- a/src/actions/common.ts
+++ b/src/actions/common.ts
@@ -32,7 +32,7 @@ export interface CheckoutOptions {
   submodules?: boolean | "recursive";
 }
 export function checkout(options: CheckoutOptions = {}): UsesStep {
-  return uses("actions/checkout@v4", buildWith(options));
+  return uses("actions/checkout@v5", buildWith(options));
 }
 
 // AddToProject action

--- a/tests/render-yaml.test.ts
+++ b/tests/render-yaml.test.ts
@@ -119,7 +119,7 @@ jobs:
     name: Test actions
     runs-on: macos-latest
     steps: 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with: 
           go-version: 1.17.7


### PR DESCRIPTION
## Why

GitHub Actions runs are now annotating every workflow that uses \`actions/checkout@v4\` with a Node.js 20 deprecation warning:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

Currently \`src/actions/common.ts:35\` hard-codes \`actions/checkout@v4\`, which means downstream users of \`@jlarky/gha-ts\` (lima-escape, lima-code, gha-ts-v2, this repo's own example workflows) all get the warning on every run.

## What

- Change the default in \`checkout()\` from \`@v4\` to \`@v5\` (one line).
- Update the inline snapshot in \`tests/render-yaml.test.ts\`.
- Regenerate \`example-{bun,javascript,node}.generated.yml\` to pick up v5.

This repo's *own* workflows (\`gha-ts.generated.yml\` etc.) were already on v5 via a local override in \`.github/workflows/utils/steps.ts\`. The bump matters for anyone consuming the published library.

## Testing

- \`mise x bun -- bun test\` — 51 pass
- \`mise run typecheck\` — clean

After this lands and a release goes out, downstream repos (lima-escape, lima-code, gha-ts-v2) just need a deno.json/package.json bump and a workflow regen.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump the default checkout action to `actions/checkout@v5` to remove Node 20 warnings and align with Node 24. Regenerated example workflows now use `@v5`.

- **Dependencies**
  - Switched `checkout()` default from `actions/checkout@v4` to `@v5`.
  - Updated test snapshot.
  - Regenerated `example-*.generated.yml` to `@v5`.

- **Migration**
  - After release, bump `@jlarky/gha-ts` in your `deno.json`/`package.json` and regenerate workflows to pick up `actions/checkout@v5`.

<sup>Written for commit 06a9e73150d7ac380eec09cdaf648510b5b58e8f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

